### PR TITLE
Fixed typo

### DIFF
--- a/blackboxprotobuf/lib/types/length_delim.py
+++ b/blackboxprotobuf/lib/types/length_delim.py
@@ -229,7 +229,7 @@ def decode_message(buf, typedef=None, pos=0, end=None, group=False):
                     if 'alt_typedefs' in field_typedef:
                         # get the next higher alt field number
                         alt_field_number = str(
-                            max(map(int, field_tyepdef['alt_typedefs'].keys()))
+                            max(map(int, field_typedef['alt_typedefs'].keys()))
                             + 1)
                     else:
                         field_typedef['alt_typedefs'] = {}


### PR DESCRIPTION
Typo was crashing library in certain use cases.